### PR TITLE
Fix single line comments regexp

### DIFF
--- a/constant/index.ts
+++ b/constant/index.ts
@@ -63,4 +63,4 @@ export const KNOWN_CSS_TYPES = [
 ]
 
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
-export const singlelineCommentsRE = /\/\/.*/g
+export const singlelineCommentsRE = /\/\/.*(?=[\n\r])/g


### PR DESCRIPTION
It works for more cases with large compressed cjs bundles

testing example: [bundle.cjs.zip](https://github.com/user-attachments/files/17795771/bundle.cjs.zip) with vite-plugin-commonjs

Thanks.